### PR TITLE
Fixed client-side command injection

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,23 @@
+<p>This extension integrates Burp Suite with SQLMap.</p>
+
+<p>Requirements:</p>
+<ul>
+	<li>Jython 2.7 beta, due to the use of json.</li>
+    <li>Java 1.7 or 1.8 (the beta version of Jython 2.7 requires this).</li>
+	<li>A running instance of the SQLMap API server.</li>
+</ul>
+<p>SQLMap comes with a RESTful based server that will execute SQLMap scans. You can manually start the server 
+with: </p>
+<pre> python sqlmapapi.py -s -H &lt;ip&gt; -p &lt;port&gt;
+</pre>
+<p>Alternatively, you can use the SQLMap API tab to select the IP/Port on which to run, as well as the path to python and sqlmapapi.py on your system.
+
+</p>
+<p>Once the SQLMap API is running, you just need to right-click in the 'Request' 
+sub tab of either the Target or Proxy main tabs and choose 'SQLiPy Scan' from 
+the context menu.
+
+This will populate the SQLMap Scanner tab with information about that request.  Clicking the 'Start Scan' button will execute a scan.
+
+If the page is vulnerable to SQL injection, then these will be added to the Scanner Results tab.
+</p>

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,10 @@
+Uuid: f154175126a04bfe8edc6056f340f52e
+ExtensionType: 2
+Name: SQLiPy
+ScreenVersion: 0.5.2
+SerialVersion: 8
+MinPlatformVersion: 0
+ProOnly: True
+Author: Josh Berry @ CodeWatch
+ShortDescription: Initiates SQLMap scans directly from within Burp.
+EntryPoint: SQLiPy.py

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -4,7 +4,7 @@ Name: SQLiPy
 ScreenVersion: 0.5.2
 SerialVersion: 8
 MinPlatformVersion: 0
-ProOnly: True
+ProOnly: False
 Author: Josh Berry @ CodeWatch
 ShortDescription: Initiates SQLMap scans directly from within Burp.
 EntryPoint: SQLiPy.py

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,7 +2,7 @@ Uuid: f154175126a04bfe8edc6056f340f52e
 ExtensionType: 2
 Name: SQLiPy
 RepoName: sqli-py
-ScreenVersion: 0.5.2
+ScreenVersion: 0.5.3
 SerialVersion: 8
 MinPlatformVersion: 0
 ProOnly: False

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,9 +1,9 @@
 Uuid: f154175126a04bfe8edc6056f340f52e
 ExtensionType: 2
 Name: SQLiPy
-RepoName: sqli-py
+RepoName: sqlipy
 ScreenVersion: 0.5.3
-SerialVersion: 8
+SerialVersion: 9
 MinPlatformVersion: 0
 ProOnly: False
 Author: Josh Berry @ CodeWatch

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,6 +1,7 @@
 Uuid: f154175126a04bfe8edc6056f340f52e
 ExtensionType: 2
 Name: SQLiPy
+RepoName: sqli-py
 ScreenVersion: 0.5.2
 SerialVersion: 8
 MinPlatformVersion: 0


### PR DESCRIPTION
I removed support for starting the sqlmapapi.py process from directly in the extension, which was not recommended anyway.  This will resolve the low-risk command injection vulnerability in that feature.