### PR TITLE
Path for python

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -2,22 +2,18 @@
 
 <p>Requirements:</p>
 <ul>
-	<li>Jython 2.7 beta, due to the use of json.</li>
-    <li>Java 1.7 or 1.8 (the beta version of Jython 2.7 requires this).</li>
-	<li>A running instance of the SQLMap API server.</li>
+	<li>Jython 2.7.0 or newer</li>
+        <li>Java 1.7 or 1.8 (the beta version of Jython 2.7 requires this).</li>
+	<li>Python 2 (already installed on most Unix distributions)</li>
 </ul>
-<p>SQLMap comes with a RESTful based server that will execute SQLMap scans. You can manually start the server 
-with: </p>
-<pre> python sqlmapapi.py -s -H &lt;ip&gt; -p &lt;port&gt;
-</pre>
-<p>Alternatively, you can use the SQLMap API tab to select the IP/Port on which to run, as well as the path to python and sqlmapapi.py on your system.
 
-</p>
+<p>SQLMap is embedded within the extension; it will be automatically configured, so you can click <i>Start API</i>.
+In some cases you may need to manually adjust the configuration or run the SQLMap API manually.</p>
+
 <p>Once the SQLMap API is running, you just need to right-click in the 'Request' 
 sub tab of either the Target or Proxy main tabs and choose 'SQLiPy Scan' from 
 the context menu.
+This will populate the SQLMap Scanner tab with information about that request.  Clicking the 'Start Scan' button will execute a scan.</p>
 
-This will populate the SQLMap Scanner tab with information about that request.  Clicking the 'Start Scan' button will execute a scan.
-
-If the page is vulnerable to SQL injection, then these will be added to the Scanner Results tab.
+<p>If the page is vulnerable to SQL injection, then these will be added to the Scanner Results tab.
 </p>

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: f154175126a04bfe8edc6056f340f52e
 ExtensionType: 2
 Name: SQLiPy
 RepoName: sqli-py
-ScreenVersion: 0.5.3
-SerialVersion: 10
+ScreenVersion: 0.5.5
+SerialVersion: 11
 MinPlatformVersion: 0
 ProOnly: False
 Author: Josh Berry @ CodeWatch

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,9 +3,10 @@ ExtensionType: 2
 Name: SQLiPy Sqlmap Integration
 RepoName: sqli-py
 ScreenVersion: 0.8.2
-SerialVersion: 18
+SerialVersion: 19
 MinPlatformVersion: 0
 ProOnly: False
 Author: Josh Berry @ CodeWatch
 ShortDescription: Initiates SQLMap scans directly from within Burp.
 EntryPoint: SQLiPy.py
+BuildCommand: 

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,9 +1,9 @@
 Uuid: f154175126a04bfe8edc6056f340f52e
 ExtensionType: 2
 Name: SQLiPy
-RepoName: sqli-py
+RepoName: sqlipy
 ScreenVersion: 0.5.3
-SerialVersion: 8
+SerialVersion: 9
 MinPlatformVersion: 0
 ProOnly: False
 Author: Josh Berry @ CodeWatch

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,9 +1,9 @@
 Uuid: f154175126a04bfe8edc6056f340f52e
 ExtensionType: 2
 Name: SQLiPy
-RepoName: sqlipy
+RepoName: sqli-py
 ScreenVersion: 0.5.3
-SerialVersion: 9
+SerialVersion: 10
 MinPlatformVersion: 0
 ProOnly: False
 Author: Josh Berry @ CodeWatch


### PR DESCRIPTION
Hi Team 
I would like ask about sqlmap integrate with Burp.The issue is about keep setting by sqlmap .All time when I start Burp extension do not hold path for python.
I have to manual show path .It is any option to remember path for sqlmaps.

This is my path for python which should be keep by extension all time .??


![1](https://user-images.githubusercontent.com/32041737/197408766-5a0f23f2-4b6b-41dc-9ff4-79b5c30d624b.jpg)
