### PR TITLE
(Fix) Headers not being copied from request to sqlmap

### DIFF
--- a/SQLiPy.py
+++ b/SQLiPy.py
@@ -638,7 +638,7 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, ITab, IExtensionStateList
     self._jLabelCookie.setText('Cookies:')
     self._jLabelReferer.setText('Referer:')
     self._jLabelUA.setText('User-Agent:')
-    self._jLabelCustHeader.setText('Custom Headers:')
+    self._jLabelCustHeader.setText('Extra Headers:')
     self._jLabelParam.setText('Test Parameter(s):')
     self._jCheckTO.setText('Text Only')
     self._jLabelLevel.setText('Level:')
@@ -1082,6 +1082,7 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, ITab, IExtensionStateList
         referer = ''
         ua = ''
         cookie = ''
+        headerString = ''
 
         for header in reqHeaders:
           if re.search('^Referer', header, re.IGNORECASE) is not None:
@@ -1090,12 +1091,15 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, ITab, IExtensionStateList
             ua = re.sub('^User-Agent\:\s+', '', header, re.IGNORECASE)
           elif re.search('^Cookie', header, re.IGNORECASE) is not None:
             cookie = re.sub('^Cookie\:\s+', '', header, re.IGNORECASE)
+          elif ':' in header:
+            headerString += ("\\n" if headerString != "" else "") + header
 
         self._jTextFieldURL.setText(reqUrl)
         self._jTextData.setText(bodyData)
         self._jTextFieldCookie.setText(cookie)
         self._jTextFieldUA.setText(ua)
         self._jTextFieldReferer.setText(referer)
+        self._jTextFieldCustHeader.setText(headerString)
         self._jConfigTab.setSelectedComponent(self._jScrollPaneMain)
         self.scanMessage = message
         self.scanUrl = reqInfo.getUrl()


### PR DESCRIPTION
While sending request to plugin, the headers are not copied which makes it difficult to run for APIs that need client-id, client-secret or other such auth headers. This commit fixes this issue and copies all headers to the existing --headers functionality.

Test Case
![Screenshot 2024-06-19 184334](https://github.com/codewatchorg/sqlipy/assets/7910687/e1b35b14-f634-4f67-804b-f490181de8fc)

Before change
![Screenshot 2024-06-19 184539](https://github.com/codewatchorg/sqlipy/assets/7910687/ecec27aa-d6e4-499b-af8a-e6f8d059aede)
![Screenshot 2024-06-19 184716](https://github.com/codewatchorg/sqlipy/assets/7910687/742d5e0c-2565-40db-b67a-f22f108e3ce8)

Because the required 'Client-Id' header wasn't copied, the scanner wouldn't run properly or give correct results. Adding the header manually works, but automatically feeding the exact request would make it easier.

After change
![Screenshot 2024-06-19 190930](https://github.com/codewatchorg/sqlipy/assets/7910687/c5e8f5dc-51d9-4f91-8e86-71ba6f823e77)
![Screenshot 2024-06-19 191156](https://github.com/codewatchorg/sqlipy/assets/7910687/aad90814-c7fe-4bc7-83a4-21e5de8bbf8d)

Additionally, since all headers are copied now, it is reasonable to call the text box as 'Extra Headers' as it is written in the man pages.

Let me know if there are any questions.

